### PR TITLE
Shouldn't this be relative import?

### DIFF
--- a/emitter/__init__.py
+++ b/emitter/__init__.py
@@ -1,1 +1,1 @@
-from emitter.emitter import Emitter
+from .emitter import Emitter


### PR DESCRIPTION
Maybe I'm doing something wrong but after just pip installing this package, it
won't work on python2.

Example, fresh python inside docker, Python 3.6.4 first:

	$ docker run --rm -it python:3-alpine sh
	/ # pip install --quiet emitter-io
	/ # python -V
	Python 3.6.4
	/ # python -c 'from emitter import emitter; print(emitter.Emitter)'
	<class 'emitter.emitter.Emitter'>
	/ # cat /usr/local/lib/python3.6/site-packages/emitter/__init__.py
	from emitter.emitter import Emitter
	/ # echo 'from .emitter import Emitter' > /usr/local/lib/python3.6/site-packages/emitter/__init__.py
	/ # cat /usr/local/lib/python3.6/site-packages/emitter/__init__.py
	from .emitter import Emitter
	/ # python -c 'from emitter import emitter; print(emitter.Emitter)'
	<class 'emitter.emitter.Emitter'>
	/ #

Ok, no change... good... With Python 2.7.14:

	$ docker run --rm -it python:2-alpine sh
	/ # pip install --quiet emitter-io
	/ # python -V
	Python 2.7.14
	/ # python -c 'from emitter import emitter; print(emitter.Emitter)'
	Traceback (most recent call last):
	  File "<string>", line 1, in <module>
	  File "/usr/local/lib/python2.7/site-packages/emitter/__init__.py", line 1, in <module>
	    from emitter.emitter import Emitter
	ImportError: No module named emitter
	/ # cat /usr/local/lib/python2.7/site-packages/emitter/__init__.py
	from emitter.emitter import Emitter
	/ # echo 'from .emitter import Emitter' > /usr/local/lib/python2.7/site-packages/emitter/__init__.py
	/ # python -c 'from emitter import emitter; print(emitter.Emitter)'
	<class 'emitter.emitter.Emitter'>
	/ #

Hmmm... better? :)